### PR TITLE
demo setup

### DIFF
--- a/01 - Bicep/deploy.sh
+++ b/01 - Bicep/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 az stack sub create \
-    --name 'breezy-devconf-demo-stack' \
+    --name 'breezy-devconf-demo' \
     --location 'swedencentral' \
     --template-file 'main.bicep' \
     --action-on-unmanage 'deleteAll' \

--- a/01 - Bicep/main.bicep
+++ b/01 - Bicep/main.bicep
@@ -25,7 +25,7 @@ resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   location: deployment().location
   tags: tags
 }
-
+/* 
 module network 'modules/network.bicep' = {
   scope: resourceGroup
   name: '${deployment().name}-network'
@@ -35,3 +35,4 @@ module network 'modules/network.bicep' = {
     tags: tags
   }
 }
+ */

--- a/01 - Bicep/main.bicep
+++ b/01 - Bicep/main.bicep
@@ -25,7 +25,7 @@ resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
   location: deployment().location
   tags: tags
 }
-/* 
+
 module network 'modules/network.bicep' = {
   scope: resourceGroup
   name: '${deployment().name}-network'
@@ -35,4 +35,3 @@ module network 'modules/network.bicep' = {
     tags: tags
   }
 }
- */

--- a/03 - Pulumi/Pulumi.breezy-devconf-demo.yaml
+++ b/03 - Pulumi/Pulumi.breezy-devconf-demo.yaml
@@ -1,2 +1,0 @@
-config:
-  azure-native:location: swedencentral

--- a/03 - Pulumi/Pulumi.breezy-devconf.yaml
+++ b/03 - Pulumi/Pulumi.breezy-devconf.yaml
@@ -1,0 +1,2 @@
+config:
+  azure-native:location: swedencentral

--- a/03 - Pulumi/Pulumi.yaml
+++ b/03 - Pulumi/Pulumi.yaml
@@ -1,4 +1,4 @@
-name: breezy-devconf-pulumi-demo
+name: demo
 description: Small demo to show how Pulumi can deploy Azure infrastructure
 runtime:
   name: python

--- a/breezy-devconf-2025.code-workspace
+++ b/breezy-devconf-2025.code-workspace
@@ -1,0 +1,15 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+  		"terminal.integrated.defaultLocation": "editor",
+		"editor.fontSize": 22,
+  		"terminal.integrated.fontSize": 22,
+		"editor.cursorStyle": "block",
+		"editor.cursorBlinking": "expand",
+		"editor.wordWrap": "on"
+	}
+}


### PR DESCRIPTION
This pull request introduces several updates across deployment scripts, infrastructure configuration files, and workspace settings. The main changes include renaming resources for consistency, updating configuration files for Pulumi, commenting out a network module in the Bicep template, and adding a new workspace settings file to improve the development experience.

Resource and configuration updates:

* Renamed the Azure deployment stack in `deploy.sh` from `'breezy-devconf-demo-stack'` to `'breezy-devconf-demo'` for consistency.
* Changed the Pulumi project name in `Pulumi.yaml` from `'breezy-devconf-pulumi-demo'` to `'demo'` to simplify naming.
* Moved the Azure location configuration from `Pulumi.breezy-devconf-demo.yaml` to `Pulumi.breezy-devconf.yaml` and removed it from the former, ensuring the correct config file is used for deployments. [[1]](diffhunk://#diff-ee9def24e6790463a96d18d1ff6e6ae661933132de3e521c57c2c905239679eaL1-L2) [[2]](diffhunk://#diff-a4595d4f779936f46f5bd3924fb858c8c58f9658539f6658810930374a4fb4c9R1-R2)

Infrastructure template changes:

* Commented out the network module section in `main.bicep`, likely for troubleshooting or to temporarily disable network resource provisioning. [[1]](diffhunk://#diff-2f9f6822c19ee169d54efaa5244b43995c35d6090fd85a0587a84233a1a2f895L28-R28) [[2]](diffhunk://#diff-2f9f6822c19ee169d54efaa5244b43995c35d6090fd85a0587a84233a1a2f895R38)

Development environment improvements:

* Added a new VS Code workspace file `breezy-devconf-2025.code-workspace` with customized editor and terminal settings to enhance the coding experience.